### PR TITLE
Update EXAMPLES.md with more detailed nsenter example

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -124,7 +124,7 @@ EchoHTTPd.yaml port=8080
 ## 🪳 Run a program in another pid namespace
 
 You can execute a program (including a shell) in another's pid namespace. 
-If you are using ```kubectl debug```:
+If you are using ```kubectl debug pod-to-debug -it --image nmaguiar/netutils --target=container-to-debug --profile=sysadmin -- /bin/bash```:
 
 ```bash
 nsenter -t [target pid] -m -u -n -i sh


### PR DESCRIPTION
This pull request includes a small change to the `EXAMPLES.md` file. The change updates the `kubectl debug` command to include additional parameters for specifying the image, target container, and profile.

* [`EXAMPLES.md`](diffhunk://#diff-30bf75f8f19e56642c61ecaa902d4d6a0a0126a234b800d76b79a7f1faab8be2L127-R127): Updated the `kubectl debug` command with additional parameters (`pod-to-debug -it --image nmaguiar/netutils --target=container-to-debug --profile=sysadmin -- /bin/bash`).