### PR TITLE
debian alternative support

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -55,6 +55,15 @@ jobs:
         platforms: linux/amd64
         tags: nmaguiar/netutils:build-x64
 
+    - uses: docker/build-push-action@v3
+      name: Build and push deb
+      with:
+        context: .
+        file: ./Dockerfile.deb
+        push: true
+        platforms: linux/amd64
+        tags: nmaguiar/netutils:deb-build-x64
+
 
   build-arm64:
 
@@ -100,6 +109,15 @@ jobs:
         push: true
         tags: nmaguiar/netutils:build-arm64
 
+    - uses: docker/build-push-action@v3
+      name: Build and push deb
+      with:
+        context: .
+        file: ./Dockerfile.deb
+        platforms: linux/arm64
+        push: true
+        tags: nmaguiar/netutils:deb-build-arm64
+
   manifest:
 
     runs-on: ubuntu-latest
@@ -117,3 +135,7 @@ jobs:
     - name: Create and push multi-arch manifest
       run : |
         docker buildx imagetools create --tag nmaguiar/netutils:build nmaguiar/netutils:build-x64 nmaguiar/netutils:build-arm64
+
+    - name: Create and push multi-arch manifest deb
+      run : |
+        docker buildx imagetools create --tag nmaguiar/netutils:deb-build nmaguiar/netutils:deb-build-x64 nmaguiar/netutils:deb-build-arm64

--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -1,0 +1,165 @@
+FROM openaf/oaf:deb as main
+
+USER root
+RUN apt update\
+ && apt upgrade -y\
+ && apt dist-upgrade -y\
+ && apt autoremove -y\
+ && DEBIAN_FRONTEND="noninteractive" apt-get install -y -qq less man-db manpages tar wget gzip bash tmux vim iperf tcpdump nmap ldnsutils iftop netcat-openbsd lynx iproute2 iptables fping conntrack iputils-ping iputils-tracepath iputils-arping iputils-clockdiff iptraf-ng ngrep tcptraceroute socat mtr termshark curl inetutils-telnet bash-completion python3 sysstat iotop htop mc iproute2-doc tinyproxy mitmproxy strace\
+ && CTOP_VERSION=$(/openaf/oafp url="https://api.github.com/repos/bcicen/ctop/releases" from="equals(draft, false).equals(prerelease, false).sort(-published_at).at(0)" opath="replace(tag_name,'^v','','')")\
+ && wget -L https://github.com/bcicen/ctop/releases/download/v$CTOP_VERSION/ctop-$CTOP_VERSION-linux-$(if [ "$(uname -m)" = "x86_64" ]; then echo 'amd64'; else echo 'arm64'; fi) -O /usr/bin/ctop\
+ && chmod +x /usr/bin/ctop\
+ && wget -O /usr/bin/websocat https://github.com/vi/websocat/releases/latest/download/websocat.$(uname -m)-unknown-linux-musl\
+ && chmod +x /usr/bin/websocat\
+ && /openaf/opack install SocksServer\
+ && /openaf/opack install Morse\
+ && /openaf/opack install oJob-common\
+ && mkdir /openaf/ojobs\
+ && /openaf/ojob ojob.io/get job=ojob.io/oaf/colorFormats.yaml > /openaf/ojobs/colorFormats.yaml\
+ && /openaf/ojob ojob.io/get job=ojob.io/net/doh.yaml > /openaf/ojobs/doh.yaml\
+ && /openaf/ojob ojob.io/get job=ojob.io/net/jdbc.yaml > /openaf/ojobs/jdbc.yaml\
+ && /openaf/ojob ojob.io/get job=ojob.io/net/latency.yaml > /openaf/ojobs/latency.yaml\
+ && /openaf/ojob ojob.io/get job=ojob.io/net/publicIP.yaml > /openaf/ojobs/publicIP.yaml\
+ && /openaf/ojob ojob.io/get job=ojob.io/net/sslDates.yaml > /openaf/ojobs/sslDates.yaml\
+ && /openaf/ojob ojob.io/get job=ojob.io/net/whois.yaml > /openaf/ojobs/whois.yaml\
+ && /openaf/ojob ojob.io/get job=ojob.io/net/testHosts.yaml > /openaf/ojobs/testHosts.yaml\
+ && /openaf/ojob ojob.io/get job=ojob.io/email/send.yaml > /openaf/ojobs/emailSend.yaml\
+ && /openaf/ojob ojob.io/get job=ojob.io/ssh/tunnel.yaml > /openaf/ojobs/tunnel.yaml\
+ && /openaf/ojob ojob.io/get job=ojob.io/httpServers/EasyHTTPSd.yaml > /openaf/ojobs/EasyHTTPSd.yaml\
+ && /openaf/ojob ojob.io/get job=ojob.io/httpServers/EasyHTTPd.yaml > /openaf/ojobs/EasyHTTPd.yaml\
+ && /openaf/ojob ojob.io/get job=ojob.io/httpServers/EchoHTTPd.yaml > /openaf/ojobs/EchoHTTPd.yaml\
+ && /openaf/ojob ojob.io/get job=ojob.io/httpServers/MetricsHTTPd.yaml > /openaf/ojobs/MetricsHTTPd.yaml\
+ && /openaf/ojob ojob.io/get job=ojob.io/httpServers/RedirectHTTPd.yaml > /openaf/ojobs/RedirectHTTPd.yaml\
+ && /openaf/ojob ojob.io/get job=ojob.io/httpServers/uploadHTTPSd.yaml > /openaf/ojobs/uploadHTTPSd.yaml\
+ && /openaf/ojob ojob.io/get job=ojob.io/httpServers/uploadHTTPd.yaml > /openaf/ojobs/uploadHTTPd.yaml\
+ && /openaf/ojob ojob.io/get job=ojob.io/formats/postman2posting.yaml > /openaf/ojobs/postman2posting.yaml\
+ && cd /openaf/ojobs\
+ && /openaf/ojob ojob.io/get airgap=true job=ojob.io/grid/data/gc2\
+ && mv ojob.io_grid_data_gc2.yaml javaGC.yaml\
+ && sed javaGC.yaml -i -e "s/ojob.io_grid_show.yaml/\/openaf\/ojobs\/ojob.io_grid_show.yaml/"\
+ && /openaf/oaf --sb /openaf/ojobs/colorFormats.yaml\
+ && /openaf/oaf --sb /openaf/ojobs/doh.yaml\
+ && /openaf/oaf --sb /openaf/ojobs/jdbc.yaml\
+ && /openaf/oaf --sb /openaf/ojobs/latency.yaml\
+ && /openaf/oaf --sb /openaf/ojobs/publicIP.yaml\
+ && /openaf/oaf --sb /openaf/ojobs/sslDates.yaml\
+ && /openaf/oaf --sb /openaf/ojobs/whois.yaml\
+ && /openaf/oaf --sb /openaf/ojobs/testHosts.yaml\
+ && /openaf/oaf --sb /openaf/ojobs/emailSend.yaml\
+ && /openaf/oaf --sb /openaf/ojobs/javaGC.yaml\
+ && /openaf/oaf --sb /openaf/ojobs/tunnel.yaml\
+ && /openaf/oaf --sb /openaf/ojobs/EasyHTTPSd.yaml\
+ && /openaf/oaf --sb /openaf/ojobs/EasyHTTPd.yaml\
+ && /openaf/oaf --sb /openaf/ojobs/EchoHTTPd.yaml\
+ && /openaf/oaf --sb /openaf/ojobs/MetricsHTTPd.yaml\
+ && /openaf/oaf --sb /openaf/ojobs/RedirectHTTPd.yaml\
+ && /openaf/oaf --sb /openaf/ojobs/uploadHTTPSd.yaml\
+ && /openaf/oaf --sb /openaf/ojobs/uploadHTTPd.yaml\
+ && /openaf/oaf --sb /openaf/ojobs/postman2posting.yaml\
+ && chown -R openaf:0 /openaf\
+ && chown openaf:0 /openaf/.opack.db\
+ && chmod -R u+rwx,g+rwx,o+rx,o-w /openaf/*\
+ && chmod a+rwx /openaf\
+ && sudo chmod g+w /openaf/.opack.db\
+ && sudo useradd -u 666 -m --shell /bin/bash mitm 2>/dev/null
+
+COPY ojobs/softVersions.yaml /openaf/ojobs/softVersions.yaml
+COPY ojobs/socksProxy.yaml /openaf/ojobs/socksProxy.yaml
+
+RUN /openaf/oaf --sb /openaf/ojobs/softVersions.yaml\
+ && chown openaf:0 /openaf/ojobs/softVersions.yaml\
+ && chmod u+rwx,g+rwx,o+rx /openaf/ojobs/softVersions.yaml\
+ && /openaf/oaf --sb /openaf/ojobs/socksProxy.yaml\
+ && chown openaf:0 /openaf/ojobs/socksProxy.yaml\
+ && chmod u+rwx,g+rwx,o+rx /openaf/ojobs/socksProxy.yaml
+
+# Setup posting
+# -------------
+RUN apt-get install -y -qq python3-pip python3-certifi python3-h11\
+ && apt-get remove -y python3-typing-extensions\
+ && pip install posting --break-system-packages\
+ && apt-get remove -y python3-pip\
+ && apt-get autoremove -y\
+ && apt-get clean -y\
+ && rm -rf /var/lib/apt/lists/*\
+ && rm -rf /tmp/*\
+ && rm -rf /var/tmp/*\
+ && rm -rf /var/cache/apt/archives/*\
+ && rm -rf /var/cache/debconf/*\
+ && rm -rf /var/cache/dictionaries-common/*
+
+# Setup netutils folder
+# ---------------------
+RUN mkdir /netutils\
+ && chmod a+rwx /netutils\
+ && chown openaf:0 /netutils\
+ && mkdir -p /run/lock
+
+# Setup welcome message and vars
+# ------------------------------
+COPY welcome.txt /etc/netutils
+RUN gzip /etc/netutils\
+ && mkdir /etc/bash\
+ && echo "zcat /etc/netutils.gz" >> /etc/bash/start.sh\
+ && echo "echo ''" >> /etc/bash/start.sh\
+ && echo "alias oafptab='oafp in=lines linesvisual=true linesjoin=true out=ctable'" >> /etc/bash/start.sh\
+ && echo "alias oaf-light-theme='colorFormats.yaml op=set theme=thin-light-bold'" >> /etc/bash/start.sh\
+ && echo "alias oaf-dark-theme='colorFormats.yaml op=set theme=thin-intense-bold'" >> /etc/bash/start.sh\
+ && echo "alias help='source /etc/bash/start.sh'" >> /etc/bash/start.sh\
+ && echo "export PATH=$PATH:/openaf:/openaf/ojobs:/opt/python/bin" >> /etc/bash/start.sh\
+ && cp /etc/bash/start.sh /etc/profile.d/start.sh
+    
+# Add bash completion
+# -------------------
+
+RUN /openaf/oaf --bashcompletion all > /openaf/.openaf_completion.sh\
+ && chmod a+x /openaf/.openaf_*.sh\
+ && chown openaf:0 /openaf/.openaf_*.sh\
+ && echo ". /openaf/.openaf_completion.sh" >> /etc/bash/start.sh
+
+# Documentation
+# -------------
+COPY USAGE.md /USAGE.md
+COPY EXAMPLES.md /EXAMPLES.md
+COPY MITM.md /openaf/MITM.md
+COPY POSTING.md /openaf/POSTING.md
+RUN gzip /USAGE.md\
+ && gzip /EXAMPLES.md\
+ && gzip /openaf/MITM.md\
+ && gzip /openaf/POSTING.md\
+ && echo "#!/bin/sh" > /usr/bin/usage-help\
+ && echo "#!/bin/sh" > /usr/bin/examples-help\
+ && echo "#!/bin/sh" > /usr/bin/mitm-help\
+ && echo "#!/bin/sh" > /usr/bin/posting-help\
+ && echo "zcat /USAGE.md.gz | oafp in=md mdtemplate=true | less -r" >> /usr/bin/usage-help\
+ && echo "zcat /EXAMPLES.md.gz | oafp in=md mdtemplate=true | less -r" >> /usr/bin/examples-help\
+ && echo "zcat /openaf/MITM.md.gz | oafp in=md mdtemplate=true | less -r" >> /usr/bin/mitm-help\
+ && echo "zcat /openaf/POSTING.md.gz | oafp in=md mdtemplate=true | less -r" >> /usr/bin/posting-help\
+ && chmod a+x /usr/bin/usage-help\
+ && chmod a+x /usr/bin/examples-help\
+ && chmod a+x /usr/bin/mitm-help\
+ && chmod a+x /usr/bin/posting-help
+
+# Copy scripts
+# ------------
+COPY scripts/* /usr/bin/
+RUN chmod a+x /usr/bin/mitm-transparent*\
+ && chmod a+x /usr/bin/mitm-gencerts.sh\
+ && chmod a+x /usr/bin/sysstat-start.sh\
+ && chmod a+x /usr/bin/sysstat-stop.sh\
+ && chmod a+x /usr/bin/switch-user-by-pid.sh\
+ && chmod a+x /usr/bin/switch-fs-by-pid.sh\
+ && chmod a+x /usr/bin/posting-export.sh\
+ && chmod a+x /usr/bin/posting-import.sh
+
+# -------------------
+FROM scratch as final
+
+COPY --from=main / /
+
+ENV OAF_HOME=/openaf
+ENV PATH=$PATH:$OAF_HOME:$OAF_HOME/ojobs
+USER openaf
+
+WORKDIR /netutils
+CMD ["/usr/bin/usage-help"]


### PR DESCRIPTION
This pull request includes significant changes to the CI/CD workflow and the addition of a new Dockerfile for building a Debian-based image to support new versions of mitmproxy, incompatible with Alpine Linux. The most important changes include updates to the GitHub Actions workflow for building and pushing Docker images, and the creation of a comprehensive `Dockerfile.deb` for a Debian-based environment.

### CI/CD Workflow Updates:
* [`.github/workflows/build-image.yml`](diffhunk://#diff-8b50c1c8ac07bc956388add66e256e8336ae22fd2cac8d83f770e1dc63674c00R58-R66): Added steps to build and push Debian-based Docker images for both `linux/amd64` and `linux/arm64` platforms. [[1]](diffhunk://#diff-8b50c1c8ac07bc956388add66e256e8336ae22fd2cac8d83f770e1dc63674c00R58-R66) [[2]](diffhunk://#diff-8b50c1c8ac07bc956388add66e256e8336ae22fd2cac8d83f770e1dc63674c00R112-R120)
* [`.github/workflows/build-image.yml`](diffhunk://#diff-8b50c1c8ac07bc956388add66e256e8336ae22fd2cac8d83f770e1dc63674c00R138-R141): Added a step to create and push a multi-arch manifest for the Debian-based Docker images.

### New Dockerfile for Debian-based Image:
* [`Dockerfile.deb`](diffhunk://#diff-ecc2ebe6e33785340d50f6680fc6b571f6a210ddc5639b871e1e3ebfc639dd66R1-R165): Created a new Dockerfile that sets up a Debian-based environment with various utilities and tools, including network utilities, OpenAF jobs, and documentation.