### PR TITLE
Add sslproxy support to lite image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt update\
  && apt upgrade -y\
  && apt dist-upgrade -y\
  && apt autoremove -y\
- && DEBIAN_FRONTEND="noninteractive" apt-get install -y -qq cron locales less man-db manpages tar wget gzip bash tmux vim iperf tcpdump nmap ldnsutils iftop netcat-openbsd lynx iproute2 iptables fping conntrack iputils-ping iputils-tracepath iputils-arping iputils-clockdiff iptraf-ng ngrep tcptraceroute socat mtr termshark curl inetutils-telnet bash-completion python3 sysstat iotop htop mc tinyproxy strace whois ifstat net-tools\
+ && DEBIAN_FRONTEND="noninteractive" apt-get install -y -qq cron locales less man-db manpages tar wget gzip bash tmux vim iperf tcpdump nmap ldnsutils iftop netcat-openbsd lynx iproute2 iptables fping conntrack iputils-ping iputils-tracepath iputils-arping iputils-clockdiff iptraf-ng ngrep tcptraceroute socat mtr termshark curl inetutils-telnet bash-completion python3 sysstat iotop htop mc tinyproxy strace openssl whois ifstat net-tools\
  && wget -O /usr/bin/websocat https://github.com/vi/websocat/releases/latest/download/websocat_max.$(uname -m)-unknown-linux-musl\
  && locale-gen en_US.UTF-8\
  && chmod +x /usr/bin/websocat\
@@ -57,7 +57,8 @@ RUN apt update\
  && chmod -R u+rwx,g+rwx,o+rx,o-w /openaf/*\
  && chmod a+rwx /openaf\
  && sudo chmod g+w /openaf/.opack.db\
- && sudo useradd -u 666 -m --shell /bin/bash mitm 2>/dev/null
+ && sudo useradd -u 666 -m --shell /bin/bash mitm 2>/dev/null\
+ && sudo useradd -u 667 -m --shell /bin/bash sslproxy 2>/dev/null
 
 COPY ojobs/softVersions.yaml /openaf/ojobs/softVersions.yaml
 COPY ojobs/socksProxy.yaml /openaf/ojobs/socksProxy.yaml
@@ -137,27 +138,33 @@ COPY USAGE.md /USAGE.md
 COPY EXAMPLES.md /EXAMPLES.md
 COPY MITM.md /openaf/MITM.md
 COPY POSTING.md /openaf/POSTING.md
+COPY SSLPROXY.md /openaf/SSLPROXY.md
 RUN gzip /USAGE.md\
  && gzip /EXAMPLES.md\
  && gzip /openaf/MITM.md\
+ && gzip /openaf/SSLPROXY.md\
  && gzip /openaf/POSTING.md\
  && echo "#!/bin/sh" > /usr/bin/usage-help\
  && echo "#!/bin/sh" > /usr/bin/examples-help\
  && echo "#!/bin/sh" > /usr/bin/mitm-help\
+ && echo "#!/bin/sh" > /usr/bin/sslproxy-help\
  && echo "#!/bin/sh" > /usr/bin/posting-help\
  && echo "zcat /USAGE.md.gz | oafp in=md mdtemplate=true | less -r" >> /usr/bin/usage-help\
  && echo "zcat /EXAMPLES.md.gz | oafp in=md mdtemplate=true | less -r" >> /usr/bin/examples-help\
  && echo "zcat /openaf/MITM.md.gz | oafp in=md mdtemplate=true | less -r" >> /usr/bin/mitm-help\
+ && echo "zcat /openaf/SSLPROXY.md.gz | oafp in=md mdtemplate=true | less -r" >> /usr/bin/sslproxy-help\
  && echo "zcat /openaf/POSTING.md.gz | oafp in=md mdtemplate=true | less -r" >> /usr/bin/posting-help\
  && chmod a+x /usr/bin/usage-help\
  && chmod a+x /usr/bin/examples-help\
  && chmod a+x /usr/bin/mitm-help\
+ && chmod a+x /usr/bin/sslproxy-help\
  && chmod a+x /usr/bin/posting-help
 
 # Copy scripts
 # ------------
 COPY scripts/* /usr/bin/
 RUN chmod a+x /usr/bin/mitm-transparent*\
+ && chmod a+x /usr/bin/sslproxy-*\
  && chmod a+x /usr/bin/mitm-gencerts.sh\
  && chmod a+x /usr/bin/sysstat-start.sh\
  && chmod a+x /usr/bin/sysstat-stop.sh\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,64 +1,73 @@
-FROM openaf/oaf:deb-nightly as main
+FROM openaf/oaf:deb-nightly AS main
 
 USER root
-RUN apt update\
- && apt upgrade -y\
- && apt dist-upgrade -y\
- && apt autoremove -y\
- && DEBIAN_FRONTEND="noninteractive" apt-get install -y -qq cron locales less man-db manpages tar wget gzip bash tmux vim iperf tcpdump nmap ldnsutils iftop netcat-openbsd lynx iproute2 iptables fping conntrack iputils-ping iputils-tracepath iputils-arping iputils-clockdiff iptraf-ng ngrep tcptraceroute socat mtr termshark curl inetutils-telnet bash-completion python3 sysstat iotop htop mc tinyproxy strace openssl whois ifstat net-tools\
- && wget -O /usr/bin/websocat https://github.com/vi/websocat/releases/latest/download/websocat_max.$(uname -m)-unknown-linux-musl\
- && locale-gen en_US.UTF-8\
- && chmod +x /usr/bin/websocat\
- && /openaf/opack install SocksServer Morse oJob-common\
- && mkdir /openaf/ojobs\
- && curl -s https://ojob.io/oaf/colorFormats.yaml > /openaf/ojobs/colorFormats.yaml\
- && curl -s https://ojob.io/net/doh.yaml > /openaf/ojobs/doh.yaml\
- && curl -s https://ojob.io/net/jdbc.yaml > /openaf/ojobs/jdbc.yaml\
- && curl -s https://ojob.io/net/latency.yaml > /openaf/ojobs/latency.yaml\
- && curl -s https://ojob.io/net/publicIP.yaml > /openaf/ojobs/publicIP.yaml\
- && curl -s https://ojob.io/net/sslDates.yaml > /openaf/ojobs/sslDates.yaml\
- && curl -s https://ojob.io/net/whois.yaml > /openaf/ojobs/whois.yaml\
- && curl -s https://ojob.io/net/testHosts.yaml > /openaf/ojobs/testHosts.yaml\
- && curl -s https://ojob.io/email/send.yaml > /openaf/ojobs/emailSend.yaml\
- && curl -s https://ojob.io/ssh/tunnel.yaml > /openaf/ojobs/tunnel.yaml\
- && curl -s https://ojob.io/httpServers/EasyHTTPSd.yaml > /openaf/ojobs/EasyHTTPSd.yaml\
- && curl -s https://ojob.io/httpServers/EasyHTTPd.yaml > /openaf/ojobs/EasyHTTPd.yaml\
- && curl -s https://ojob.io/httpServers/EchoHTTPd.yaml > /openaf/ojobs/EchoHTTPd.yaml\
- && curl -s https://ojob.io/httpServers/MetricsHTTPd.yaml > /openaf/ojobs/MetricsHTTPd.yaml\
- && curl -s https://ojob.io/httpServers/RedirectHTTPd.yaml > /openaf/ojobs/RedirectHTTPd.yaml\
- && curl -s https://ojob.io/httpServers/uploadHTTPSd.yaml > /openaf/ojobs/uploadHTTPSd.yaml\
- && curl -s https://ojob.io/httpServers/uploadHTTPd.yaml > /openaf/ojobs/uploadHTTPd.yaml\
- && curl -s https://ojob.io/formats/postman2posting.yaml > /openaf/ojobs/postman2posting.yaml\
- && cd /openaf/ojobs\
- && /openaf/ojob ojob.io/get airgap=true job=ojob.io/grid/data/gc2\
- && mv ojob.io_grid_data_gc2.yaml javaGC.yaml\
- && sed javaGC.yaml -i -e "s/ojob.io_grid_show.yaml/\/openaf\/ojobs\/ojob.io_grid_show.yaml/"\
- && /openaf/oaf --sb /openaf/ojobs/colorFormats.yaml\
- && /openaf/oaf --sb /openaf/ojobs/doh.yaml\
- && /openaf/oaf --sb /openaf/ojobs/jdbc.yaml\
- && /openaf/oaf --sb /openaf/ojobs/latency.yaml\
- && /openaf/oaf --sb /openaf/ojobs/publicIP.yaml\
- && /openaf/oaf --sb /openaf/ojobs/sslDates.yaml\
- && /openaf/oaf --sb /openaf/ojobs/whois.yaml\
- && /openaf/oaf --sb /openaf/ojobs/testHosts.yaml\
- && /openaf/oaf --sb /openaf/ojobs/emailSend.yaml\
- && /openaf/oaf --sb /openaf/ojobs/javaGC.yaml\
- && /openaf/oaf --sb /openaf/ojobs/tunnel.yaml\
- && /openaf/oaf --sb /openaf/ojobs/EasyHTTPSd.yaml\
- && /openaf/oaf --sb /openaf/ojobs/EasyHTTPd.yaml\
- && /openaf/oaf --sb /openaf/ojobs/EchoHTTPd.yaml\
- && /openaf/oaf --sb /openaf/ojobs/MetricsHTTPd.yaml\
- && /openaf/oaf --sb /openaf/ojobs/RedirectHTTPd.yaml\
- && /openaf/oaf --sb /openaf/ojobs/uploadHTTPSd.yaml\
- && /openaf/oaf --sb /openaf/ojobs/uploadHTTPd.yaml\
- && /openaf/oaf --sb /openaf/ojobs/postman2posting.yaml\
- && chown -R openaf:0 /openaf\
- && chown openaf:0 /openaf/.opack.db\
- && chmod -R u+rwx,g+rwx,o+rx,o-w /openaf/*\
- && chmod a+rwx /openaf\
- && sudo chmod g+w /openaf/.opack.db\
- && sudo useradd -u 666 -m --shell /bin/bash mitm 2>/dev/null\
- && sudo useradd -u 667 -m --shell /bin/bash sslproxy 2>/dev/null
+RUN set -eux; \
+  export DEBIAN_FRONTEND="noninteractive"; \
+  apt-get clean; \
+  rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* /var/cache/apt/archives/partial/* /tmp/* /var/tmp/*; \
+  apt-get update; \
+  apt-get install -y -qq --no-install-recommends \
+    cron locales tar wget gzip bash tmux vim less man-db manpages bash-completion python3 inetutils-telnet; \
+  rm -rf /var/cache/apt/archives/* /var/cache/apt/archives/partial/*; \
+  apt-get install -y -qq --no-install-recommends \
+    curl iperf tcpdump nmap ldnsutils iftop netcat-openbsd lynx iproute2 iptables fping conntrack iputils-ping iputils-tracepath iputils-arping iputils-clockdiff iptraf-ng ngrep tcptraceroute socat mtr termshark; \
+  rm -rf /var/cache/apt/archives/* /var/cache/apt/archives/partial/*; \
+  apt-get install -y -qq --no-install-recommends \
+    sysstat iotop htop mc tinyproxy strace openssl whois ifstat net-tools; \
+  rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* /var/cache/apt/archives/partial/* /tmp/* /var/tmp/*; \
+  wget -O /usr/bin/websocat https://github.com/vi/websocat/releases/latest/download/websocat_max.$(uname -m)-unknown-linux-musl; \
+  locale-gen en_US.UTF-8; \
+  chmod +x /usr/bin/websocat; \
+  /openaf/opack install SocksServer Morse oJob-common; \
+  mkdir /openaf/ojobs; \
+  curl -s https://ojob.io/oaf/colorFormats.yaml > /openaf/ojobs/colorFormats.yaml; \
+  curl -s https://ojob.io/net/doh.yaml > /openaf/ojobs/doh.yaml; \
+  curl -s https://ojob.io/net/jdbc.yaml > /openaf/ojobs/jdbc.yaml; \
+  curl -s https://ojob.io/net/latency.yaml > /openaf/ojobs/latency.yaml; \
+  curl -s https://ojob.io/net/publicIP.yaml > /openaf/ojobs/publicIP.yaml; \
+  curl -s https://ojob.io/net/sslDates.yaml > /openaf/ojobs/sslDates.yaml; \
+  curl -s https://ojob.io/net/whois.yaml > /openaf/ojobs/whois.yaml; \
+  curl -s https://ojob.io/net/testHosts.yaml > /openaf/ojobs/testHosts.yaml; \
+  curl -s https://ojob.io/email/send.yaml > /openaf/ojobs/emailSend.yaml; \
+  curl -s https://ojob.io/ssh/tunnel.yaml > /openaf/ojobs/tunnel.yaml; \
+  curl -s https://ojob.io/httpServers/EasyHTTPSd.yaml > /openaf/ojobs/EasyHTTPSd.yaml; \
+  curl -s https://ojob.io/httpServers/EasyHTTPd.yaml > /openaf/ojobs/EasyHTTPd.yaml; \
+  curl -s https://ojob.io/httpServers/EchoHTTPd.yaml > /openaf/ojobs/EchoHTTPd.yaml; \
+  curl -s https://ojob.io/httpServers/MetricsHTTPd.yaml > /openaf/ojobs/MetricsHTTPd.yaml; \
+  curl -s https://ojob.io/httpServers/RedirectHTTPd.yaml > /openaf/ojobs/RedirectHTTPd.yaml; \
+  curl -s https://ojob.io/httpServers/uploadHTTPSd.yaml > /openaf/ojobs/uploadHTTPSd.yaml; \
+  curl -s https://ojob.io/httpServers/uploadHTTPd.yaml > /openaf/ojobs/uploadHTTPd.yaml; \
+  curl -s https://ojob.io/formats/postman2posting.yaml > /openaf/ojobs/postman2posting.yaml; \
+  cd /openaf/ojobs; \
+  /openaf/ojob ojob.io/get airgap=true job=ojob.io/grid/data/gc2; \
+  mv ojob.io_grid_data_gc2.yaml javaGC.yaml; \
+  sed -i -e "s/ojob.io_grid_show.yaml/\\/openaf\\/ojobs\\/ojob.io_grid_show.yaml/" javaGC.yaml; \
+  /openaf/oaf --sb /openaf/ojobs/colorFormats.yaml; \
+  /openaf/oaf --sb /openaf/ojobs/doh.yaml; \
+  /openaf/oaf --sb /openaf/ojobs/jdbc.yaml; \
+  /openaf/oaf --sb /openaf/ojobs/latency.yaml; \
+  /openaf/oaf --sb /openaf/ojobs/publicIP.yaml; \
+  /openaf/oaf --sb /openaf/ojobs/sslDates.yaml; \
+  /openaf/oaf --sb /openaf/ojobs/whois.yaml; \
+  /openaf/oaf --sb /openaf/ojobs/testHosts.yaml; \
+  /openaf/oaf --sb /openaf/ojobs/emailSend.yaml; \
+  /openaf/oaf --sb /openaf/ojobs/javaGC.yaml; \
+  /openaf/oaf --sb /openaf/ojobs/tunnel.yaml; \
+  /openaf/oaf --sb /openaf/ojobs/EasyHTTPSd.yaml; \
+  /openaf/oaf --sb /openaf/ojobs/EasyHTTPd.yaml; \
+  /openaf/oaf --sb /openaf/ojobs/EchoHTTPd.yaml; \
+  /openaf/oaf --sb /openaf/ojobs/MetricsHTTPd.yaml; \
+  /openaf/oaf --sb /openaf/ojobs/RedirectHTTPd.yaml; \
+  /openaf/oaf --sb /openaf/ojobs/uploadHTTPSd.yaml; \
+  /openaf/oaf --sb /openaf/ojobs/uploadHTTPd.yaml; \
+  /openaf/oaf --sb /openaf/ojobs/postman2posting.yaml; \
+  chown -R openaf:0 /openaf; \
+  chown openaf:0 /openaf/.opack.db; \
+  chmod -R u+rwx,g+rwx,o+rx,o-w /openaf/*; \
+  chmod a+rwx /openaf; \
+  chmod g+w /openaf/.opack.db; \
+  useradd -u 666 -m --shell /bin/bash mitm 2>/dev/null || true; \
+  useradd -u 667 -m --shell /bin/bash sslproxy 2>/dev/null || true
 
 COPY ojobs/softVersions.yaml /openaf/ojobs/softVersions.yaml
 COPY ojobs/socksProxy.yaml /openaf/ojobs/socksProxy.yaml
@@ -72,8 +81,10 @@ RUN /openaf/oaf --sb /openaf/ojobs/softVersions.yaml\
 
 # Setup posting
 # -------------
-RUN apt-get install -y -qq python3-pip python3-certifi python3-h11\
- && apt-get remove -y python3-typing-extensions\
+RUN set -eux\
+ && apt-get update\
+ && apt-get install -y -qq --no-install-recommends python3-pip python3-certifi python3-h11\
+ && (apt-get remove -y python3-typing-extensions || true)\
  && pip install posting --break-system-packages\
  && apt-get remove -y python3-pip\
  && apt-get autoremove -y\
@@ -179,13 +190,13 @@ FROM golang:latest AS lazydocker-builder
 RUN go install github.com/jesseduffield/lazydocker@latest
 
 # ----------------------
-FROM scratch as prefinal
+FROM scratch AS prefinal
 
 COPY --from=main / /
 COPY --from=lazydocker-builder /go/bin/lazydocker /usr/bin/lazydocker
 
 # -------------------
-FROM scratch as final
+FROM scratch AS final
 
 COPY --from=prefinal / /
 

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -1,10 +1,10 @@
-FROM openaf/oaf:edge as main
+FROM openaf/oaf:edge AS main
 
 USER root
 RUN sed -i 's/v[0-9]*\.[0-9]*/edge/g' /etc/apk/repositories\
  && apk update\
  && apk upgrade --available\
- && apk --no-cache add tar gzip bash tmux vim iperf iperf-doc tcpdump tcpdump-doc nmap nmap-doc iftop iftop-doc drill netcat-openbsd netcat-openbsd-doc lynx lynx-doc iproute2 iproute2-doc iptables iptables-doc fping fping-doc conntrack-tools conntrack-tools-doc lazydocker iputils iptraf-ng iptraf-ng-doc ngrep ngrep-doc tcptraceroute tcptraceroute-doc socat socat-doc mtr mtr-doc termshark curl curl-doc inetutils-telnet websocat bash-completion python3 sysstat sysstat-doc iotop iotop-doc htop htop-doc mc mandoc man-pages util-linux-doc tinyproxy tinyproxy-doc strace strace-doc procps openssl sslproxy sslproxy-doc\
+ && apk --no-cache add tar gzip bash tmux vim iperf iperf-doc tcpdump tcpdump-doc nmap nmap-doc iftop iftop-doc drill netcat-openbsd netcat-openbsd-doc lynx lynx-doc iproute2 iproute2-doc iptables iptables-doc fping fping-doc conntrack-tools conntrack-tools-doc lazydocker iputils iptraf-ng iptraf-ng-doc ngrep ngrep-doc tcptraceroute tcptraceroute-doc socat socat-doc mtr mtr-doc termshark curl curl-doc inetutils-telnet websocat bash-completion python3 sysstat sysstat-doc iotop iotop-doc htop htop-doc mc mandoc man-pages util-linux-doc tinyproxy tinyproxy-doc strace strace-doc procps openssl\
  && /openaf/opack install SocksServer Morse oJob-common\
  && mkdir /openaf/ojobs\
  && curl -s https://ojob.io/oaf/colorFormats.yaml > /openaf/ojobs/colorFormats.yaml\
@@ -27,7 +27,7 @@ RUN sed -i 's/v[0-9]*\.[0-9]*/edge/g' /etc/apk/repositories\
  && cd /openaf/ojobs\
  && /openaf/ojob ojob.io/get airgap=true job=ojob.io/grid/data/gc2\
  && mv ojob.io_grid_data_gc2.yaml javaGC.yaml\
- && sed javaGC.yaml -i -e "s/ojob.io_grid_show.yaml/\/openaf\/ojobs\/ojob.io_grid_show.yaml/"\
+ && sed -i -e "s/ojob.io_grid_show.yaml/\\/openaf\\/ojobs\\/ojob.io_grid_show.yaml/" javaGC.yaml\
  && /openaf/oaf --sb /openaf/ojobs/colorFormats.yaml\
  && /openaf/oaf --sb /openaf/ojobs/doh.yaml\
  && /openaf/oaf --sb /openaf/ojobs/jdbc.yaml\
@@ -50,9 +50,9 @@ RUN sed -i 's/v[0-9]*\.[0-9]*/edge/g' /etc/apk/repositories\
  && chown openaf:0 /openaf/.opack.db\
  && chmod -R u+rwx,g+rwx,o+rx,o-w /openaf/*\
  && chmod a+rwx /openaf\
- && sudo chmod g+w /openaf/.opack.db\
- && sudo adduser mitm -u 666 -D 2>/dev/null\
- && sudo adduser sslproxy -u 667 -D 2>/dev/null
+ && chmod g+w /openaf/.opack.db\
+ && adduser mitm -u 666 -D 2>/dev/null || true\
+ && adduser sslproxy -u 667 -D 2>/dev/null || true
 
 COPY ojobs/softVersions.yaml /openaf/ojobs/softVersions.yaml
 COPY ojobs/socksProxy.yaml /openaf/ojobs/socksProxy.yaml
@@ -76,6 +76,8 @@ RUN mkdir /netutils\
 COPY welcome.txt /etc/netutils
 RUN echo " (lite version)" >> /etc/netutils\
  && gzip /etc/netutils\
+ && mkdir -p /etc/bash\
+ && mkdir -p /etc/profile.d\
  && echo "zcat /etc/netutils.gz" >> /etc/bash/start.sh\
  && echo "echo ''" >> /etc/bash/start.sh\
  && echo "alias oafptab='oafp in=lines linesvisual=true linesjoin=true out=ctable'" >> /etc/bash/start.sh\
@@ -90,7 +92,7 @@ RUN echo " (lite version)" >> /etc/netutils\
 
 RUN /openaf/oaf --bashcompletion all > /openaf/.openaf_completion.sh\
  && chmod a+x /openaf/.openaf_*.sh\
- && chown openaf:openaf /openaf/.openaf_*.sh\
+ && chown openaf:0 /openaf/.openaf_*.sh\
  && echo ". /openaf/.openaf_completion.sh" >> /etc/bash/start.sh
 
 # Documentation
@@ -121,7 +123,7 @@ RUN chmod a+x /usr/bin/sslproxy-*\
  && chmod a+x /usr/bin/switch-fs-by-pid.sh
 
 # -------------------
-FROM scratch as final
+FROM scratch AS final
 
 COPY --from=main / /
 

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -4,7 +4,7 @@ USER root
 RUN sed -i 's/v[0-9]*\.[0-9]*/edge/g' /etc/apk/repositories\
  && apk update\
  && apk upgrade --available\
- && apk --no-cache add tar gzip bash tmux vim iperf iperf-doc tcpdump tcpdump-doc nmap nmap-doc iftop iftop-doc drill netcat-openbsd netcat-openbsd-doc lynx lynx-doc iproute2 iproute2-doc iptables iptables-doc fping fping-doc conntrack-tools conntrack-tools-doc lazydocker iputils iptraf-ng iptraf-ng-doc ngrep ngrep-doc tcptraceroute tcptraceroute-doc socat socat-doc mtr mtr-doc termshark curl curl-doc inetutils-telnet websocat bash-completion python3 sysstat sysstat-doc iotop iotop-doc htop htop-doc mc mandoc man-pages util-linux-doc tinyproxy tinyproxy-doc strace strace-doc procps\
+ && apk --no-cache add tar gzip bash tmux vim iperf iperf-doc tcpdump tcpdump-doc nmap nmap-doc iftop iftop-doc drill netcat-openbsd netcat-openbsd-doc lynx lynx-doc iproute2 iproute2-doc iptables iptables-doc fping fping-doc conntrack-tools conntrack-tools-doc lazydocker iputils iptraf-ng iptraf-ng-doc ngrep ngrep-doc tcptraceroute tcptraceroute-doc socat socat-doc mtr mtr-doc termshark curl curl-doc inetutils-telnet websocat bash-completion python3 sysstat sysstat-doc iotop iotop-doc htop htop-doc mc mandoc man-pages util-linux-doc tinyproxy tinyproxy-doc strace strace-doc procps openssl sslproxy sslproxy-doc\
  && /openaf/opack install SocksServer Morse oJob-common\
  && mkdir /openaf/ojobs\
  && curl -s https://ojob.io/oaf/colorFormats.yaml > /openaf/ojobs/colorFormats.yaml\
@@ -51,7 +51,8 @@ RUN sed -i 's/v[0-9]*\.[0-9]*/edge/g' /etc/apk/repositories\
  && chmod -R u+rwx,g+rwx,o+rx,o-w /openaf/*\
  && chmod a+rwx /openaf\
  && sudo chmod g+w /openaf/.opack.db\
- && sudo adduser mitm -u 666 -D 2>/dev/null
+ && sudo adduser mitm -u 666 -D 2>/dev/null\
+ && sudo adduser sslproxy -u 667 -D 2>/dev/null
 
 COPY ojobs/softVersions.yaml /openaf/ojobs/softVersions.yaml
 COPY ojobs/socksProxy.yaml /openaf/ojobs/socksProxy.yaml
@@ -96,19 +97,25 @@ RUN /openaf/oaf --bashcompletion all > /openaf/.openaf_completion.sh\
 # -------------
 COPY USAGE.md /USAGE.md
 COPY EXAMPLES.md /EXAMPLES.md
+COPY SSLPROXY.md /openaf/SSLPROXY.md
 RUN gzip /USAGE.md\
  && gzip /EXAMPLES.md\
+ && gzip /openaf/SSLPROXY.md\
  && echo "#!/bin/sh" > /usr/bin/usage-help\
  && echo "#!/bin/sh" > /usr/bin/examples-help\
+ && echo "#!/bin/sh" > /usr/bin/sslproxy-help\
  && echo "zcat /USAGE.md.gz | oafp in=md mdtemplate=true | less -r" >> /usr/bin/usage-help\
  && echo "zcat /EXAMPLES.md.gz | oafp in=md mdtemplate=true | less -r" >> /usr/bin/examples-help\
+ && echo "zcat /openaf/SSLPROXY.md.gz | oafp in=md mdtemplate=true | less -r" >> /usr/bin/sslproxy-help\
  && chmod a+x /usr/bin/usage-help\
- && chmod a+x /usr/bin/examples-help
+ && chmod a+x /usr/bin/examples-help\
+ && chmod a+x /usr/bin/sslproxy-help
 
 # Copy scripts
 # ------------
 COPY scripts/* /usr/bin/
-RUN chmod a+x /usr/bin/sysstat-start.sh\
+RUN chmod a+x /usr/bin/sslproxy-*\
+ && chmod a+x /usr/bin/sysstat-start.sh\
  && chmod a+x /usr/bin/sysstat-stop.sh\
  && chmod a+x /usr/bin/switch-user-by-pid.sh\
  && chmod a+x /usr/bin/switch-fs-by-pid.sh

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Image ("nmaguiar/netutils") with tools for network connectivity debugging (with 
 Some of the included tools:
 
 - mitmproxy
+- sslproxy
 - termshark
 - openaf
 - iotop
@@ -74,4 +75,3 @@ Host network:
 ```bash
 NODENAME=node-server-0 NAME=netutils NS=kube-system  /bin/sh -c 'kubectl run -n $NS $NAME --rm -ti --image=nmaguiar/netutils  --overrides="{\"apiVersion\":\"v1\",\"spec\":{\"hostNetwork\":true,\"nodeName\":\"$NODENAME\",\"containers\":[{\"name\":\"$NAME\",\"image\":\"nmaguiar/netutils\",\"stdin\":true,\"stdinOnce\":true,\"tty\":true,\"args\":[\"/bin/bash\"]}]}}" -- /bin/bash'
 ```
-

--- a/SSLPROXY.md
+++ b/SSLPROXY.md
@@ -1,0 +1,103 @@
+# sslproxy
+
+`sslproxy` is a transparent TLS proxy that can decrypt, inspect, and forward encrypted traffic. The helper scripts included with this image focus on running `sslproxy` in transparent mode so that HTTPS traffic redirected by iptables is intercepted and re-encrypted with a locally generated CA certificate.
+
+## 🔐 Copying the CA certificate
+
+`sslproxy` needs a CA certificate and key so that it can generate leaf certificates for the intercepted connections. The helper scripts expect them to live under `~/.sslproxy/ca.crt` and `~/.sslproxy/ca.key`.
+
+### Pre-generating
+
+To pre-generate these CA certificates and copy them to another environment, run:
+
+```bash
+docker run --rm -ti nmaguiar/netutils sslproxy-gencerts.sh
+```
+
+This prints a base64-encoded tarball you can paste into another shell script. Inside the destination container, prepare the `sslproxy` home and unpack the tarball:
+
+```bash
+sudo -u sslproxy bash
+mkdir -p ~/.sslproxy
+cd ~/.sslproxy
+# execute the printed command from sslproxy-gencerts.sh
+```
+
+Once the CA certificate is trusted by your clients, `sslproxy` can forge certificates for intercepted TLS sessions.
+
+## ⚙️ Usage
+
+The helper scripts focus on transparent mode interception. The default listening port is `8443`, and you can override it with the `SSLPROXY_PORT` environment variable.
+
+### Quick start in transparent mode
+
+1. **Exclude sslproxy’s own traffic** so it isn’t re-intercepted:
+
+```bash
+sslproxy-transparent-set.sh
+```
+
+2. **Redirect traffic to sslproxy** (choose the commands you need):
+
+> If you need to redirect port 8443 but also want `sslproxy` to listen on another port, set `SSLPROXY_PORT` accordingly before running the scripts.
+
+- Outgoing IPv4 TCP:
+
+```bash
+sslproxy-transparent-add.sh port [host]
+```
+
+- Outgoing IPv6 TCP:
+
+```bash
+sslproxy-transparent-add6.sh port [host]
+```
+
+- Incoming IPv4 on `eth0`:
+
+```bash
+sslproxy-transparent-add-incoming.sh port [host]
+```
+
+- Incoming IPv6 on `eth0`:
+
+```bash
+sslproxy-transparent-add6-incoming.sh port [host]
+```
+
+3. **Start sslproxy** (runs as user `sslproxy`, default port `8443`):
+
+```bash
+sslproxy-transparent-start.sh
+```
+
+This command auto-generates a CA if it doesn’t exist, writes a simple config to `/home/sslproxy/sslproxy.conf`, and starts `sslproxy` with a proxyspec of `https 0.0.0.0 <SSLPROXY_PORT>`. You can pass extra arguments to `sslproxy` by setting the `SSLPROXY_EXTRA_ARGS` environment variable before starting the service.
+
+4. **Remove individual redirection rules** when you’re done:
+
+Use one or more of the following:
+
+```bash
+sslproxy-transparent-clean.sh port [host]
+sslproxy-transparent-clean6.sh port [host]
+sslproxy-transparent-clean-incoming.sh port [host]
+sslproxy-transparent-clean6-incoming.sh port [host]
+```
+
+Or, simply:
+
+5. **Clean up all sslproxy iptables chains** (bypass, NAT, etc.):
+
+```bash
+sslproxy-transparent-cleanall.sh
+```
+
+### Manual invocation
+
+If you prefer to run `sslproxy` directly, ensure your CA files exist in `~/.sslproxy` and then run:
+
+```bash
+sudo -u sslproxy sslproxy -k ~/.sslproxy/ca.key -c ~/.sslproxy/ca.crt https 0.0.0.0 8443
+```
+
+Append any additional proxyspecs or runtime options as needed (for example, to change modes, logging, or protocol handling). Check `sslproxy --help` for the full list of options.

--- a/USAGE.md
+++ b/USAGE.md
@@ -121,6 +121,7 @@ Profiles:
 | rtstat | yes | Displaying routing statistics. |  |
 | sadf | yes | System activity data formatter. Helps convert data collected by sar info formats like CSV, XML, JSON, etc. |  |
 | sar | yes | System activity reporter. Can monitor various system metrics such as CPU usage, memory, disk I/O, network activity and more |  |
+| sslproxy | yes | Transparent TLS proxy to decrypt and divert traffic with a custom CA certificate. | sslproxy-help |
 | socat | yes | Multipurpose relay for bidirectional data transfer between two independent data channels. |  |
 | strace | yes | Trace system calls and signals. | |
 | switch-fs-by-pid.sh | yes | Switches to the filesystem of a provided pid. | |

--- a/ojobs/softVersions.yaml
+++ b/ojobs/softVersions.yaml
@@ -39,6 +39,9 @@ init:
   - name: mitmproxy
     cmd : mitmproxy --version
     lite: false
+  - name: sslproxy
+    cmd : sslproxy -V || true
+    lite: true
   - name: mtr
     cmd : mtr -v
   - name: mpstat

--- a/scripts/sslproxy-gencerts.sh
+++ b/scripts/sslproxy-gencerts.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+SSLPROXY_STATE_DIR="${SSLPROXY_STATE_DIR:-${HOME}/.sslproxy}"
+mkdir -p "$SSLPROXY_STATE_DIR"
+
+CA_KEY="${SSLPROXY_STATE_DIR}/ca.key"
+CA_CERT="${SSLPROXY_STATE_DIR}/ca.crt"
+
+if [ ! -f "$CA_KEY" ] || [ ! -f "$CA_CERT" ]; then
+  openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/CN=Netutils SSLproxy CA" -keyout "$CA_KEY" -out "$CA_CERT"
+fi
+
+tar czf /tmp/sslproxycerts.tgz -C "$SSLPROXY_STATE_DIR" .
+CERTS=$(base64 /tmp/sslproxycerts.tgz | tr -d '\n')
+
+echo "---"
+echo "copy the following command from the clipboard to another file (editing with vi, for example):"
+echo ""
+echo "echo $CERTS | base64 -d | tar xz"
+echo ""
+echo "---"
+echo "Then you can execute the file, as shell script, to get the certificates in another pod or container"
+echo ""

--- a/scripts/sslproxy-transparent-add-incoming.sh
+++ b/scripts/sslproxy-transparent-add-incoming.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Usage: sslproxy-transparent-add-incoming.sh <port> [<host>]
+# Example: sslproxy-transparent-add-incoming.sh 443 www.google.com
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: sslproxy-transparent-add-incoming.sh <port> [<host>]"
+    exit 1
+fi
+
+SSLPROXY_PORT="${SSLPROXY_PORT:-8443}"
+
+# Redirect the traffic to the proxy
+if [ "$#" -eq 2 ]; then
+    sudo iptables -t nat -A PREROUTING  -p tcp -i eth0  -d $2 --dport $1 -j REDIRECT --to-ports $SSLPROXY_PORT
+    sudo iptables -t nat -A OUTPUT      -p tcp          -d $2 --dport $1 -j REDIRECT --to-ports $SSLPROXY_PORT
+else
+    sudo iptables -t nat -A PREROUTING  -p tcp -i eth0   --dport $1 -j REDIRECT --to-ports $SSLPROXY_PORT
+    sudo iptables -t nat -A OUTPUT      -p tcp           --dport $1 -j REDIRECT --to-ports $SSLPROXY_PORT
+fi

--- a/scripts/sslproxy-transparent-add.sh
+++ b/scripts/sslproxy-transparent-add.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Usage: sslproxy-transparent-add.sh <port> [<host>]
+# Example: sslproxy-transparent-add.sh 443 www.google.com
+
+SSLPROXY_PORT="${SSLPROXY_PORT:-8443}"
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: sslproxy-transparent-add.sh <port> [<host>]"
+    exit 1
+fi
+
+# Redirect the traffic to the proxy
+if [ "$#" -eq 2 ]; then
+    sudo iptables -t nat -A OUTPUT -p tcp -d $2 --dport $1 -j DNAT --to-destination 127.0.0.1:$SSLPROXY_PORT
+else
+    sudo iptables -t nat -A OUTPUT -p tcp --dport $1 -j DNAT --to-destination 127.0.0.1:$SSLPROXY_PORT
+fi

--- a/scripts/sslproxy-transparent-add6-incoming.sh
+++ b/scripts/sslproxy-transparent-add6-incoming.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Usage: sslproxy-transparent-add6-incoming.sh <port> [<host>]
+# Example: sslproxy-transparent-add6-incoming.sh 443 www.google.com
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: sslproxy-transparent-add6-incoming.sh <port> [<host>]"
+    exit 1
+fi
+
+SSLPROXY_PORT="${SSLPROXY_PORT:-8443}"
+
+# Redirect the traffic to the proxy
+if [ "$#" -eq 2 ]; then
+    sudo ip6tables -t nat -A PREROUTING  -p tcp -i eth0  -d $2 --dport $1 -j REDIRECT --to-ports $SSLPROXY_PORT
+    sudo ip6tables -t nat -A OUTPUT      -p tcp          -d $2 --dport $1 -j REDIRECT --to-ports $SSLPROXY_PORT
+else
+    sudo ip6tables -t nat -A PREROUTING  -p tcp -i eth0   --dport $1 -j REDIRECT --to-ports $SSLPROXY_PORT
+    sudo ip6tables -t nat -A OUTPUT      -p tcp           --dport $1 -j REDIRECT --to-ports $SSLPROXY_PORT
+fi

--- a/scripts/sslproxy-transparent-add6.sh
+++ b/scripts/sslproxy-transparent-add6.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Usage: sslproxy-transparent-add6.sh <port> [<host>]
+# Example: sslproxy-transparent-add6.sh 443 www.google.com
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: sslproxy-transparent-add6.sh <port> [<host>]"
+    exit 1
+fi
+
+SSLPROXY_PORT="${SSLPROXY_PORT:-8443}"
+
+# Redirect the traffic to the proxy
+if [ "$#" -eq 2 ]; then
+    sudo ip6tables -t nat -A OUTPUT -p tcp -d $2 --dport $1 -j DNAT --to-destination [::1]:$SSLPROXY_PORT
+else
+    sudo ip6tables -t nat -A OUTPUT -p tcp --dport $1 -j DNAT --to-destination [::1]:$SSLPROXY_PORT
+fi

--- a/scripts/sslproxy-transparent-clean-incoming.sh
+++ b/scripts/sslproxy-transparent-clean-incoming.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Usage: sslproxy-transparent-clean-incoming.sh <port> [<host>]
+# Example: sslproxy-transparent-clean-incoming.sh 443
+
+# SSLPROXY_PORT is defined for consistency with related scripts, though not used here.
+SSLPROXY_PORT="${SSLPROXY_PORT:-8443}"
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: sslproxy-transparent-clean-incoming.sh <port> [<host>]"
+    exit 1
+fi
+
+# Remove the redirection to the proxy
+if [ "$#" -eq 2 ]; then
+    sudo iptables -t nat -D PREROUTING -p tcp -i eth0 -d $2 --dport $1
+    sudo iptables -t nat -D OUTPUT     -p tcp -d $2 --dport $1
+else
+    sudo iptables -t nat -D PREROUTING -p tcp -i eth0 --dport $1
+    sudo iptables -t nat -D OUTPUT     -p tcp --dport $1
+fi

--- a/scripts/sslproxy-transparent-clean.sh
+++ b/scripts/sslproxy-transparent-clean.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Usage: sslproxy-transparent-clean.sh <port> [<host>]
+# Example: sslproxy-transparent-clean.sh 443
+
+# SSLPROXY_PORT is defined for consistency with related scripts, though not used here.
+SSLPROXY_PORT="${SSLPROXY_PORT:-8443}"
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: sslproxy-transparent-clean.sh <port> [<host>]"
+    exit 1
+fi
+
+# Remove the redirection to the proxy
+if [ "$#" -eq 2 ]; then
+    sudo iptables -t nat -D OUTPUT -p tcp -d $2 --dport $1
+else
+    sudo iptables -t nat -D OUTPUT -p tcp --dport $1
+fi

--- a/scripts/sslproxy-transparent-clean6-incoming.sh
+++ b/scripts/sslproxy-transparent-clean6-incoming.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Usage: sslproxy-transparent-clean6-incoming.sh <port> [<host>]
+# Example: sslproxy-transparent-clean6-incoming.sh 443
+
+# SSLPROXY_PORT is defined for consistency with related scripts, though not used here.
+SSLPROXY_PORT="${SSLPROXY_PORT:-8443}"
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: sslproxy-transparent-clean6-incoming.sh <port> [<host>]"
+    exit 1
+fi
+
+# Remove the redirection to the proxy
+if [ "$#" -eq 2 ]; then
+    sudo ip6tables -t nat -D PREROUTING -p tcp -i eth0 -d $2 --dport $1
+    sudo ip6tables -t nat -D OUTPUT     -p tcp -d $2 --dport $1
+else
+    sudo ip6tables -t nat -D PREROUTING -p tcp -i eth0 --dport $1
+    sudo ip6tables -t nat -D OUTPUT     -p tcp --dport $1
+fi

--- a/scripts/sslproxy-transparent-clean6.sh
+++ b/scripts/sslproxy-transparent-clean6.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Usage: sslproxy-transparent-clean6.sh <port> [<host>]
+# Example: sslproxy-transparent-clean6.sh 443
+
+# SSLPROXY_PORT is defined for consistency with related scripts, though not used here.
+SSLPROXY_PORT="${SSLPROXY_PORT:-8443}"
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: sslproxy-transparent-clean6.sh <port> [<host>]"
+    exit 1
+fi
+
+# Remove the redirection to the proxy
+if [ "$#" -eq 2 ]; then
+    sudo ip6tables -t nat -D OUTPUT -p tcp -d $2 --dport $1
+else    
+    sudo ip6tables -t nat -D OUTPUT -p tcp --dport $1
+fi

--- a/scripts/sslproxy-transparent-cleanall.sh
+++ b/scripts/sslproxy-transparent-cleanall.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Usage: sslproxy-transparent-cleanall.sh
+# Example: sslproxy-transparent-cleanall.sh
+
+# SSLPROXY_PORT is defined for consistency with related scripts, though not used here.
+SSLPROXY_PORT="${SSLPROXY_PORT:-8443}"
+
+sudo iptables -t nat -F OUTPUT 
+sudo iptables -t nat -F PREROUTING
+sudo iptables -t mangle -D OUTPUT -m owner --uid-owner sslproxy -j MARK --set-mark 2
+sudo iptables -t mangle -F SSLPROXY_BYPASS
+sudo iptables -t mangle -X SSLPROXY_BYPASS
+
+sudo ip6tables -t nat -F OUTPUT 
+sudo ip6tables -t nat -F PREROUTING
+sudo ip6tables -t mangle -D OUTPUT -m owner --uid-owner sslproxy -j MARK --set-mark 2
+sudo ip6tables -t mangle -F SSLPROXY_BYPASS
+sudo ip6tables -t mangle -X SSLPROXY_BYPASS

--- a/scripts/sslproxy-transparent-set.sh
+++ b/scripts/sslproxy-transparent-set.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+SSLPROXY_PORT="${SSLPROXY_PORT:-8443}"
+
+sudo iptables -t mangle -N SSLPROXY_BYPASS 2>/dev/null || true
+sudo iptables -t mangle -C OUTPUT -m owner --uid-owner sslproxy -j MARK --set-mark 2 2>/dev/null || sudo iptables -t mangle -A OUTPUT -m owner --uid-owner sslproxy -j MARK --set-mark 2
+sudo iptables -t nat -C OUTPUT -m mark --mark 2 -j RETURN 2>/dev/null || sudo iptables -t nat -A OUTPUT -m mark --mark 2 -j RETURN
+
+sudo ip6tables -t mangle -N SSLPROXY_BYPASS 2>/dev/null || true
+sudo ip6tables -t mangle -C OUTPUT -m owner --uid-owner sslproxy -j MARK --set-mark 2 2>/dev/null || sudo ip6tables -t mangle -A OUTPUT -m owner --uid-owner sslproxy -j MARK --set-mark 2
+sudo ip6tables -t nat -C OUTPUT -m mark --mark 2 -j RETURN 2>/dev/null || sudo ip6tables -t nat -A OUTPUT -m mark --mark 2 -j RETURN

--- a/scripts/sslproxy-transparent-start.sh
+++ b/scripts/sslproxy-transparent-start.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+SSLPROXY_PORT="${SSLPROXY_PORT:-8443}"
+SSLPROXY_STATE_DIR="${SSLPROXY_STATE_DIR:-/home/sslproxy/.sslproxy}"
+SSLPROXY_CONF="${SSLPROXY_CONF:-/home/sslproxy/sslproxy.conf}"
+SSLPROXY_PROXYSPEC="${SSLPROXY_PROXYSPEC:-https 0.0.0.0 $SSLPROXY_PORT}"
+SSLPROXY_EXTRA_ARGS="${SSLPROXY_EXTRA_ARGS:-}"
+
+sudo -u sslproxy mkdir -p "$SSLPROXY_STATE_DIR"
+
+if [ ! -f "$SSLPROXY_STATE_DIR/ca.key" ] || [ ! -f "$SSLPROXY_STATE_DIR/ca.crt" ]; then
+  sudo -u sslproxy openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/CN=Netutils SSLproxy CA" -keyout "$SSLPROXY_STATE_DIR/ca.key" -out "$SSLPROXY_STATE_DIR/ca.crt"
+fi
+
+cat <<EOF | sudo -u sslproxy tee "$SSLPROXY_CONF" > /dev/null
+CACert $SSLPROXY_STATE_DIR/ca.crt
+CAKey $SSLPROXY_STATE_DIR/ca.key
+Passthrough yes
+ProxySpec $SSLPROXY_PROXYSPEC
+EOF
+
+exec sudo -u sslproxy sslproxy -f "$SSLPROXY_CONF" $SSLPROXY_EXTRA_ARGS


### PR DESCRIPTION
## Summary
- install sslproxy in the lite image, add a dedicated user, and expose docs via a new sslproxy-help command
- add helper scripts for transparent sslproxy usage including CA generation and traffic redirection
- document sslproxy usage and update usage tables/version checks to reflect the new tooling

## Testing
- not run (not requested)

